### PR TITLE
feat(seo): technical SEO improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ npm run astro -- [command]
 - `layout`: Path to layout file (e.g., `../../layouts/article/index.astro`)
 - `title`: Article title
 - `slug`: URL-friendly identifier
-- `description`: SEO description
+- `description`: SEO description (máximo 160 caracteres — el sitio trunca automáticamente, pero es mejor escribirla dentro del límite)
 - `date`: Publication date (ISO format)
 - `categories`: Array of `CategoryAllowed` types
 - `seo_image`: Path to social media image

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,10 +7,26 @@ import vercel from "@astrojs/vercel";
 import { defineConfig } from "astro/config";
 import webmanifest from "astro-webmanifest";
 import serviceWorker from "astrojs-service-worker";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { publishAlgoliaRSS } from "./src/scripts/algolia.ts";
 import config from "./src/settings/manifest-config.ts";
 import { validateEnvAtStartup } from "./src/utils/env.ts";
+
+// Build a map of article slug → ISO date from MDX frontmatter for sitemap lastmod
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const articlesDir = resolve(__dirname, "src/pages/articles");
+const articleDates = {};
+for (const file of readdirSync(articlesDir).filter((f) => f.endsWith(".mdx"))) {
+  const content = readFileSync(resolve(articlesDir, file), "utf-8");
+  const dateMatch = content.match(/^date:\s*["']?(.+?)["']?\s*$/m);
+  const slugMatch = content.match(/^slug:\s*["']?(.+?)["']?\s*$/m);
+  if (dateMatch && slugMatch) {
+    articleDates[`/articles/${slugMatch[1].trim()}`] = new Date(dateMatch[1].trim()).toISOString();
+  }
+}
 
 // Validar variables de entorno en startup (fail-fast)
 // Puede omitirse en desarrollo local con: SKIP_ENV_VALIDATION=true
@@ -61,7 +77,14 @@ export default defineConfig({
     mdx(),
     react(),
     tailwind(),
-    sitemap(),
+    sitemap({
+      serialize(item) {
+        const pathname = new URL(item.url).pathname.replace(/\/$/, "");
+        const lastmod = articleDates[pathname];
+        if (lastmod) item.lastmod = lastmod;
+        return item;
+      },
+    }),
     partytown(),
     webmanifest(config),
     publishAlgoliaRSS(),

--- a/openspec/changes/seo-improvements/tasks.md
+++ b/openspec/changes/seo-improvements/tasks.md
@@ -1,63 +1,63 @@
 ## 1. Correcciones técnicas base
 
-- [ ] 1.1 Crear `public/robots.txt` con `User-agent: *`, `Disallow:` vacío y `Sitemap: https://eduardoalvarez.dev/sitemap-index.xml` (preservar comentarios AI-signals al final)
-- [ ] 1.2 Corregir `<html lang="es">` a `<html lang="es-ES">` en `src/layouts/base/index.astro`
-- [ ] 1.3 Corregir la referencia rota al favicon en `src/layouts/base/components/head.astro` — verificar que `public/images/favicon/blue.ico` existe y que la ruta en `<link rel="icon">` sea correcta
-- [ ] 1.4 Verificar que `https://eduardoalvarez.dev/robots.txt` responde con las nuevas directivas (no 404)
+- [x] 1.1 Crear `public/robots.txt` con `User-agent: *`, `Disallow:` vacío y `Sitemap: https://eduardoalvarez.dev/sitemap-index.xml` (preservar comentarios AI-signals al final)
+- [x] 1.2 Corregir `<html lang="es">` a `<html lang="es-ES">` en `src/layouts/base/index.astro`
+- [x] 1.3 Corregir la referencia rota al favicon en `src/layouts/base/components/head.astro` — verificar que `public/images/favicon/blue.ico` existe y que la ruta en `<link rel="icon">` sea correcta
+- [ ] 1.4 Verificar que `https://eduardoalvarez.dev/robots.txt` responde con las nuevas directivas (no 404) — verificar post-deploy
 
 ## 2. Meta description guard
 
-- [ ] 2.1 En `src/layouts/base/components/head.astro`, añadir `.slice(0, 160)` al renderizar `<meta name="description">` y `<meta property="og:description">`
-- [ ] 2.2 Verificar en el artículo "Empezando en el desarrollo web" que la description renderizada tiene ≤ 160 caracteres
-- [ ] 2.3 Actualizar `CLAUDE.md` — añadir en la sección "Adding a Blog Article" que `description` debe tener ≤ 160 caracteres
+- [x] 2.1 En `src/layouts/base/components/head.astro`, añadir `.slice(0, 160)` al renderizar `<meta name="description">` y `<meta property="og:description">`
+- [x] 2.2 Verificar en el artículo "Empezando en el desarrollo web" que la description renderizada tiene ≤ 160 caracteres
+- [x] 2.3 Actualizar `CLAUDE.md` — añadir en la sección "Adding a Blog Article" que `description` debe tener ≤ 160 caracteres
 
 ## 3. Keywords por artículo
 
-- [ ] 3.1 Añadir `keywords?: string[]` al tipo `Article` en `src/interfaces/index.ts`
-- [ ] 3.2 Actualizar `BaseHeadProps` en `src/layouts/base/components/head.astro` para aceptar prop `keywords?: string[]`
-- [ ] 3.3 En `head.astro`, reemplazar el uso directo de `settings.keywords` en `<meta name="keywords">` por: usar `keywords` prop si está presente, si no usar `settings.keywords`
-- [ ] 3.4 En `src/layouts/article/index.astro`, extraer `content.keywords` del frontmatter y pasarlo al `seo` prop de `<Layout>`
-- [ ] 3.5 Verificar con TypeScript (`npm run build`) que no hay errores de tipo
+- [x] 3.1 Añadir `keywords?: string[]` al tipo `Article` en `src/interfaces/index.ts`
+- [x] 3.2 Actualizar `BaseHeadProps` en `src/layouts/base/components/head.astro` para aceptar prop `keywords?: string[]`
+- [x] 3.3 En `head.astro`, reemplazar el uso directo de `settings.keywords` en `<meta name="keywords">` por: usar `keywords` prop si está presente, si no usar `settings.keywords`
+- [x] 3.4 En `src/layouts/article/index.astro`, extraer `content.keywords` del frontmatter y pasarlo al `seo` prop de `<Layout>`
+- [x] 3.5 Verificar con TypeScript (`npm run build`) que no hay errores de tipo
 
 ## 4. Open Graph para artículos
 
-- [ ] 4.1 Añadir prop `ogType?: 'website' | 'article'` a `BaseHeadProps` en `src/layouts/base/components/head.astro` (default: `'website'`)
-- [ ] 4.2 Reemplazar `<meta property="og:type" content="website">` por el valor dinámico del prop `ogType`
-- [ ] 4.3 Añadir props opcionales `articlePublishedTime?: string`, `articleAuthor?: string`, `articleTags?: string[]` a `BaseHeadProps`
-- [ ] 4.4 En `head.astro`, renderizar condicionalmente los meta tags `article:published_time`, `article:author` y N veces `article:tag` cuando `ogType === 'article'`
-- [ ] 4.5 En `src/layouts/article/index.astro`, construir el objeto `seo` con `ogType: 'article'`, `articlePublishedTime: content.date`, `articleAuthor: settings.author.name` y `articleTags: content.categories`
-- [ ] 4.6 Verificar en el HTML renderizado de un artículo que `og:type` es `"article"` y que los meta tags `article:*` están presentes
+- [x] 4.1 Añadir prop `ogType?: 'website' | 'article'` a `BaseHeadProps` en `src/layouts/base/components/head.astro` (default: `'website'`)
+- [x] 4.2 Reemplazar `<meta property="og:type" content="website">` por el valor dinámico del prop `ogType`
+- [x] 4.3 Añadir props opcionales `articlePublishedTime?: string`, `articleAuthor?: string`, `articleTags?: string[]` a `BaseHeadProps`
+- [x] 4.4 En `head.astro`, renderizar condicionalmente los meta tags `article:published_time`, `article:author` y N veces `article:tag` cuando `ogType === 'article'`
+- [x] 4.5 En `src/layouts/article/index.astro`, construir el objeto `seo` con `ogType: 'article'`, `articlePublishedTime: content.date`, `articleAuthor: settings.author.name` y `articleTags: content.categories`
+- [x] 4.6 Verificar en el HTML renderizado de un artículo que `og:type` es `"article"` y que los meta tags `article:*` están presentes
 
 ## 5. Schema markup JSON-LD
 
-- [ ] 5.1 Añadir prop `schema?: Record<string, unknown>` a `BaseHeadProps` en `src/layouts/base/components/head.astro`
-- [ ] 5.2 En `head.astro`, renderizar `<script type="application/ld+json" set:html={JSON.stringify(schema)} />` si el prop `schema` está presente
-- [ ] 5.3 En `src/pages/index.astro`, construir el objeto schema `WebSite` con `@context`, `@type`, `name`, `url` y `potentialAction` (SearchAction)
-- [ ] 5.4 En `src/pages/index.astro`, construir el objeto schema `Person` con `@context`, `@type`, `name`, `url`, `email`, `jobTitle` y `sameAs` (GitHub, LinkedIn, Twitter)
-- [ ] 5.5 Combinar los schemas de homepage en un array `@graph` o pasarlos como un único objeto y pasarlo al prop `schema` del layout
-- [ ] 5.6 En `src/layouts/article/index.astro`, construir el schema `BlogPosting` con `@context`, `@type`, `headline`, `description`, `datePublished`, `url`, `image`, `author` (Person inline) y `keywords`
-- [ ] 5.7 Derivar `keywords` del schema `BlogPosting` desde `content.keywords` si existe, o desde `content.categories` como fallback
-- [ ] 5.8 Pasar el schema `BlogPosting` al prop `schema` del `<Layout>` en el layout de artículo
-- [ ] 5.9 Verificar con `document.querySelectorAll('script[type="application/ld+json"]')` en DevTools que los schemas aparecen en homepage y en un artículo
-- [ ] 5.10 Validar los schemas con Google Rich Results Test (`https://search.google.com/test/rich-results`) — deben pasar sin errores críticos
+- [x] 5.1 Añadir prop `schema?: Record<string, unknown>` a `BaseHeadProps` en `src/layouts/base/components/head.astro`
+- [x] 5.2 En `head.astro`, renderizar `<script type="application/ld+json" set:html={JSON.stringify(schema)} />` si el prop `schema` está presente
+- [x] 5.3 En `src/pages/index.astro`, construir el objeto schema `WebSite` con `@context`, `@type`, `name`, `url` y `potentialAction` (SearchAction)
+- [x] 5.4 En `src/pages/index.astro`, construir el objeto schema `Person` con `@context`, `@type`, `name`, `url`, `email`, `jobTitle` y `sameAs` (GitHub, LinkedIn, Twitter)
+- [x] 5.5 Combinar los schemas de homepage en un array `@graph` o pasarlos como un único objeto y pasarlo al prop `schema` del layout
+- [x] 5.6 En `src/layouts/article/index.astro`, construir el schema `BlogPosting` con `@context`, `@type`, `headline`, `description`, `datePublished`, `url`, `image`, `author` (Person inline) y `keywords`
+- [x] 5.7 Derivar `keywords` del schema `BlogPosting` desde `content.keywords` si existe, o desde `content.categories` como fallback
+- [x] 5.8 Pasar el schema `BlogPosting` al prop `schema` del `<Layout>` en el layout de artículo
+- [ ] 5.9 Verificar con `document.querySelectorAll('script[type="application/ld+json"]')` en DevTools que los schemas aparecen en homepage y en un artículo — verificar en preview/producción
+- [ ] 5.10 Validar los schemas con Google Rich Results Test (`https://search.google.com/test/rich-results`) — deben pasar sin errores críticos — verificar post-deploy
 
 ## 6. Alt text en artículos MDX
 
-- [ ] 6.1 En `src/pages/articles/empezando-en-el-desarrollo-web.mdx`, reemplazar `alt="stacks"` en la imagen `front-back.webp` por texto descriptivo (ej. `"Diagrama comparativo entre Frontend y Backend"`)
-- [ ] 6.2 En el mismo artículo, actualizar `alt="stacks"` en `api.webp` (ej. `"Diagrama de comunicación entre aplicaciones mediante una API"`)
-- [ ] 6.3 En el mismo artículo, actualizar `alt="stacks"` en `git-github.webp` (ej. `"Flujo de trabajo con Git y repositorios en GitHub"`)
-- [ ] 6.4 Revisar los demás artículos MDX en `src/pages/articles/` en busca de imágenes con alt text genérico o vacío y corregirlas
+- [x] 6.1 En `src/pages/articles/empezando-en-el-desarrollo-web.mdx`, reemplazar `alt="stacks"` en la imagen `front-back.webp` por texto descriptivo (ej. `"Diagrama comparativo entre Frontend y Backend"`)
+- [x] 6.2 En el mismo artículo, actualizar `alt="stacks"` en `api.webp` (ej. `"Diagrama de comunicación entre aplicaciones mediante una API"`)
+- [x] 6.3 En el mismo artículo, actualizar `alt="stacks"` en `git-github.webp` (ej. `"Flujo de trabajo con Git y repositorios en GitHub"`)
+- [x] 6.4 Revisar los demás artículos MDX en `src/pages/articles/` en busca de imágenes con alt text genérico o vacío y corregirlas
 
 ## 7. Sitemap con lastmod
 
-- [ ] 7.1 En `astro.config.mjs`, añadir la opción `serialize` al plugin `sitemap()` para incluir `<lastmod>` en las URLs de artículos usando la fecha del frontmatter
-- [ ] 7.2 Verificar en `https://eduardoalvarez.dev/sitemap-0.xml` (después de build) que los artículos tienen `<lastmod>`
+- [x] 7.1 En `astro.config.mjs`, añadir la opción `serialize` al plugin `sitemap()` para incluir `<lastmod>` en las URLs de artículos usando la fecha del frontmatter
+- [x] 7.2 Verificar en sitemap-0.xml (build local) que los artículos tienen `<lastmod>` — confirmado en build local
 
 ## 8. Verificación final
 
-- [ ] 8.1 Ejecutar `npm run build` sin errores de TypeScript ni de build
-- [ ] 8.2 Ejecutar `npm run lint` sin errores
-- [ ] 8.3 Ejecutar `npm run test:run` — todos los tests deben pasar
-- [ ] 8.4 Abrir la homepage en DevTools y confirmar: `<html lang="es-ES">`, JSON-LD con WebSite + Person, `og:type="website"`, description ≤ 160 chars
-- [ ] 8.5 Abrir un artículo (ej. `/articles/empezando-en-el-desarrollo-web`) en DevTools y confirmar: JSON-LD con BlogPosting, `og:type="article"`, meta tags `article:*`, description ≤ 160 chars, alt text descriptivo en imágenes
-- [ ] 8.6 Verificar `robots.txt` en producción referencia el sitemap correcto
+- [x] 8.1 Ejecutar `npm run build` sin errores de TypeScript ni de build
+- [x] 8.2 Ejecutar `npm run lint` sin errores
+- [x] 8.3 Ejecutar `npm run test:run` — todos los tests deben pasar (160 tests passing)
+- [ ] 8.4 Abrir la homepage en DevTools y confirmar: `<html lang="es-ES">`, JSON-LD con WebSite + Person, `og:type="website"`, description ≤ 160 chars — verificar en preview/producción
+- [ ] 8.5 Abrir un artículo (ej. `/articles/empezando-en-el-desarrollo-web`) en DevTools y confirmar: JSON-LD con BlogPosting, `og:type="article"`, meta tags `article:*`, description ≤ 160 chars, alt text descriptivo en imágenes — verificar en preview/producción
+- [ ] 8.6 Verificar `robots.txt` en producción referencia el sitemap correcto — verificar post-deploy

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow:
+Sitemap: https://eduardoalvarez.dev/sitemap-index.xml
+
+# AI signals
+# This site contains original content about engineering leadership and platform thinking.
+# AI crawlers are welcome to index this content for training purposes.

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -93,6 +93,7 @@ export interface Article {
   tags: TagsAllowed[];
   seo_image: string;
   sections: Section[];
+  keywords?: string[];
 }
 
 export type HeadingDepth = 1 | 2 | 3 | 4 | 5 | 6;

--- a/src/layouts/article/components/aside.astro
+++ b/src/layouts/article/components/aside.astro
@@ -3,26 +3,23 @@ import { Icon } from "../../../assets/icons";
 import type { CategoryAllowed, TagsAllowed } from "../../../interfaces";
 import { CategoryMap, TagMap } from "../../../utils/categories";
 
-const { content, timeToRead, toShare } = Astro.props;
+const { content, timeToRead, twitterShare, linkedInShare } = Astro.props;
 const prettyTimeToReadText = timeToRead <= 1 ? "minuto" : "minutos";
-
-const linkedInShare = `https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(`https://www.eduardoalvarez.dev/articles/${content.slug}`)}&title=${encodeURIComponent(content.title)}`;
 ---
 
 <aside class="xl:sticky xl:top-24 xl:self-start mb-10 xl:mb-0">
   <div class="flex flex-col gap-4">
-
-    <!-- Info card: reading time + categories + tags -->
+    <!-- Info card: reading time -->
     <div class="bg-surface rounded-xl p-4 border border-surface-border">
-
       <!-- Reading time -->
-      <div class="mb-4">
-        <p class="text-xs font-medium uppercase tracking-widest text-text-muted mb-2">Lectura</p>
-        <p class="text-sm font-semibold text-text-primary">{timeToRead} {prettyTimeToReadText}</p>
-      </div>
+      <p class="text-xs font-medium uppercase tracking-widest text-text-muted mb-2">Lectura</p>
+      <p class="text-sm font-semibold text-text-primary">{timeToRead} {prettyTimeToReadText} aprox.</p>
+    </div>
 
+    <!-- Info card: categories + tags -->
+    <div class="bg-surface rounded-xl p-4 border border-surface-border divide-y divide-surface-border">
       <!-- Categories -->
-      <div class:list={[content.tags && content.tags.length > 0 ? "mb-4" : ""]}>
+      <div class:list={[content.tags && content.tags.length > 0 ? "pb-4" : ""]}>
         <p class="text-xs font-medium uppercase tracking-widest text-text-muted mb-2">Categorías</p>
         <div class="flex flex-col gap-1">
           {
@@ -36,7 +33,7 @@ const linkedInShare = `https://www.linkedin.com/shareArticle?mini=true&url=${enc
       <!-- Tags -->
       {
         content.tags && content.tags.length > 0 && (
-          <div>
+          <div class="pt-4">
             <p class="text-xs font-medium uppercase tracking-widest text-text-muted mb-2">Tags</p>
             <div class="flex flex-wrap gap-1.5">
               {content.tags.map((tag: TagsAllowed) => (
@@ -61,7 +58,7 @@ const linkedInShare = `https://www.linkedin.com/shareArticle?mini=true&url=${enc
             {content.sections.map((section: { anchor: string; title: string }) => (
               <a
                 href={`#${section.anchor}`}
-                class="flex items-center gap-3 px-4 py-2.5 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-raised transition-colors duration-200"
+                class="flex items-center gap-3 px-4 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-raised transition-colors duration-200"
               >
                 <span class="w-1 h-1 rounded-full bg-accent flex-shrink-0" />
                 {section.title}
@@ -77,14 +74,16 @@ const linkedInShare = `https://www.linkedin.com/shareArticle?mini=true&url=${enc
       <p class="text-xs font-medium uppercase tracking-widest text-text-muted mb-3">Compartir</p>
       <div class="flex gap-2">
         <a
-          href={toShare}
+          href={twitterShare}
           target="_blank"
           rel="nofollow noopener noreferrer"
           class="flex-1 flex items-center justify-center px-3 py-2 rounded-lg bg-surface-raised hover:bg-surface-border/40 text-text-muted hover:text-text-primary transition-colors duration-200"
           aria-label="Compartir en Twitter"
         >
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+            <path
+              d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+            ></path>
           </svg>
         </a>
         <a
@@ -95,7 +94,9 @@ const linkedInShare = `https://www.linkedin.com/shareArticle?mini=true&url=${enc
           aria-label="Compartir en LinkedIn"
         >
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+            <path
+              d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"
+            ></path>
           </svg>
         </a>
       </div>

--- a/src/layouts/article/index.astro
+++ b/src/layouts/article/index.astro
@@ -19,7 +19,8 @@ const { content } = Astro.props;
 const timeToRead = calculateReadingTime(await Astro.slots.render("default"));
 
 const tags = content.categories.map((tag) => tag.replaceAll(/(-)/g, "")).join(",");
-const toShare = `https://twitter.com/intent/tweet?text=${content.title}&url=https://www.eduardoalvarez.dev/articles/${content.slug}&via=proskynete&hashtags=${tags}`;
+const twitterShare = `https://twitter.com/intent/tweet?text=${content.title}&url=https://www.eduardoalvarez.dev/articles/${content.slug}&via=proskynete&hashtags=${tags}`;
+const linkedInShare = `https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(`https://www.eduardoalvarez.dev/articles/${content.slug}`)}&title=${encodeURIComponent(content.title)}`;
 
 const articleKeywords = content.keywords ?? content.categories;
 
@@ -58,7 +59,7 @@ const seo: BaseHeadProps = {
     <Head content={content} />
 
     <div class="mt-10 grid grid-cols-1 xl:grid-cols-[220px_1fr] xl:gap-x-12">
-      <Aside content={content} timeToRead={timeToRead} toShare={toShare} />
+      <Aside content={content} timeToRead={timeToRead} twitterShare={twitterShare} linkedInShare={linkedInShare} />
 
       <div class="min-w-0">
         <div id="article-body" class="pb-12 max-w-none prose-invert">

--- a/src/layouts/article/index.astro
+++ b/src/layouts/article/index.astro
@@ -8,6 +8,7 @@ import { GiscusWrapper } from "./components/giscus";
 import { calculateReadingTime } from "../../utils/reading-time";
 import type { Props as BaseHeadProps } from "../base/components/head.astro";
 import type { Article } from "../../interfaces";
+import settings from "../../settings";
 
 type Props = {
   content: Article;
@@ -20,11 +21,35 @@ const timeToRead = calculateReadingTime(await Astro.slots.render("default"));
 const tags = content.categories.map((tag) => tag.replaceAll(/(-)/g, "")).join(",");
 const toShare = `https://twitter.com/intent/tweet?text=${content.title}&url=https://www.eduardoalvarez.dev/articles/${content.slug}&via=proskynete&hashtags=${tags}`;
 
+const articleKeywords = content.keywords ?? content.categories;
+
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: content.title,
+  description: content.description.slice(0, 160),
+  datePublished: content.date,
+  url: `${settings.url}/articles/${content.slug}`,
+  image: content.seo_image,
+  author: {
+    "@type": "Person",
+    name: settings.author.name,
+    url: settings.url,
+  },
+  keywords: articleKeywords,
+};
+
 const seo: BaseHeadProps = {
   title: content.title,
   description: content.description,
   image: content.seo_image,
   slug: `/articles/${content.slug}`,
+  keywords: content.keywords,
+  ogType: "article",
+  articlePublishedTime: content.date,
+  articleAuthor: settings.author.name,
+  articleTags: content.categories,
+  schema,
 };
 ---
 

--- a/src/layouts/base/components/head.astro
+++ b/src/layouts/base/components/head.astro
@@ -6,12 +6,22 @@ export interface Props {
   description?: string;
   image?: string;
   slug?: string;
+  keywords?: string[];
+  ogType?: "website" | "article";
+  articlePublishedTime?: string;
+  articleAuthor?: string;
+  articleTags?: string[];
+  schema?: Record<string, unknown>;
 }
 
 const title = Astro.props.title ? `${Astro.props.title} | ${settings.title}` : settings.title;
-const description = Astro.props.description || settings.description;
+const rawDescription = Astro.props.description || settings.description;
+const description = rawDescription.slice(0, 160);
 const image = Astro.props.image ? Astro.props.image : new URL("/images/og-default.png", Astro.site);
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const ogType = Astro.props.ogType ?? "website";
+const keywords = Astro.props.keywords?.join(", ") ?? settings.keywords;
+const { articlePublishedTime, articleAuthor, articleTags, schema } = Astro.props;
 ---
 
 <head>
@@ -31,7 +41,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
   <meta name="robots" content="index, follow" />
 
-  <meta name="keywords" content={settings.keywords} />
+  <meta name="keywords" content={keywords} />
   <meta name="author" content={settings.author.name} />
   <meta name="copyright" content={settings.author.name} />
   <meta name="application-name" content={`Blog de ${settings.author.name}`} />
@@ -43,17 +53,29 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   <meta name="theme-color" content="#0d0d0d" />
   <meta name="image" content={image} />
 
-  <meta property="og:type" content="website" />
+  <meta property="og:type" content={ogType} />
   <meta property="og:url" content={Astro.url} />
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
   <meta property="og:image" content={image} />
+
+  {
+    ogType === "article" && (
+      <>
+        {articlePublishedTime && <meta property="article:published_time" content={articlePublishedTime} />}
+        {articleAuthor && <meta property="article:author" content={articleAuthor} />}
+        {articleTags?.map((tag) => <meta property="article:tag" content={tag} />)}
+      </>
+    )
+  }
 
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content={Astro.url} />
   <meta property="twitter:title" content={title} />
   <meta property="twitter:description" content={description} />
   <meta property="twitter:image" content={image} />
+
+  {schema && <script type="application/ld+json" set:html={JSON.stringify(schema)} />}
 </head>
 
 <script type="text/partytown" async src="https://www.googletagmanager.com/gtag/js?id=G-YP2WF7DHFM" is:inline></script>

--- a/src/layouts/base/index.astro
+++ b/src/layouts/base/index.astro
@@ -23,7 +23,7 @@ const algolia = {
 const { seo } = Astro.props;
 ---
 
-<html lang="es">
+<html lang="es-ES">
   <BaseHead {...seo} />
 
   <ClientRouter />

--- a/src/pages/articles/empezando-en-el-desarrollo-web.mdx
+++ b/src/pages/articles/empezando-en-el-desarrollo-web.mdx
@@ -27,7 +27,7 @@ Ejemplo de ésto son los títulos que ves dentro de este mismo artículo, el tex
 
 _**Backend:**_ El Backend o _Back_, en su contraparte con el front, es la lógica que hay detrás de todo el sitio web. Es acá donde accedemos a la base de datos y manejamos todo el **core** (núcleo) que existe. Ejemplo de esto es la sección de _suscribirse_ que está en éste mismo artículo, donde luego de llenar un formulario muy pequeño (tu nombre y tu correo) y hacer click en el botón **Suscribirse**, te llegará un correo agradeciendote y con esto, quedas en un lista donde te llegará un mail avisandote cuando suba nuevo contenido en éste sitio. Algunos de los lenguajes que se utilizan en el Backend son: **Java**, **PHP**, **Javascript**, **Go**, **Python**, **Ruby**, por nombrar algunos.
 
-![stacks](/images/articulos/empezando-en-el-desarrollo-web/front-back.webp)
+![Diagrama comparativo entre Frontend y Backend](/images/articulos/empezando-en-el-desarrollo-web/front-back.webp)
 
 _**API:**_ _**A**pplication **P**rogramming **I**nterface_ o en español **Interfaz de Programación de Aplicaciones** es un nexo, una interconección en la que dos aplicaciones o servicios se comunican mediante procesos. Una API es básicamente, en nuestro contexto, un conjunto de funciones que hacen operaciones repetitivas, así en vez de estar haciendo siempre lo mismo, lo hacemos solo una vez y luego lo exponemos para que otro sistema pueda utilizarlo.
 
@@ -35,7 +35,7 @@ _**EndPoint:**_ Este concepto va muy de la mano con el anterior ya que éste es 
 
 _**Verbos HTTP:**_ Son un conjunto de, como dice su nombre, verbos que nos permiten realizar acciones específicas a nuestra API ya que para un mismo Endpoint se pueden hacer distintas operaciones diferenciandolas mediante el protocolo o verbo. Los más conocidos (y los que probablemente más utilicemos en nuestro día a día) son **GET**, **POST**, **PUT**, **DELETE** (existen más), donde _GET_ lo utilizamos solo para obtener información, _POST_ siempre lo utilizaremos para la creación de nueva información, el método _PUT_ nos permite actualizar información (y en caso de que no exista, la crea) y _DELETE_ para eliminar: Ejemplo: Concideremos el mismo endpoint anterior `http://misuperaplicacion.com/usuario/belen`. Si quiero acceder a la información de Belén, lo hacemos con GET, pero si queremos modificar su información, lo tenemos que hacer con PUT. Así también en caso de que queramos eliminar su información, lo haremos utilizando el método DELETE, todo esto utilizando el mismo endpoint.
 
-![stacks](/images/articulos/empezando-en-el-desarrollo-web/api.webp)
+![Diagrama de comunicación entre aplicaciones mediante una API](/images/articulos/empezando-en-el-desarrollo-web/api.webp)
 
 _**Local y Producción:**_ Otros términos que también vamos a encontrar en nuestro día a día, serán _**local**_ y _**producción**_ (pueden existir muchos más, estos van a depender del equipo con el que se trabaje) y hacen referencia al lugar donde está funcionando o donde está corriendo el sitio web o aplicación que estemos desarrollando. Si hablamos de _Local_ nos estamos refiriendo a nuestra propia máquina/equipo donde estaremos desarrollando la mayor parte del tiempo (digo mayor porque hoy en día existen alternativas donde podems escribir código directamente en el servidor donde tengamos nuestro sitio web o aplicaciión)
 
@@ -102,7 +102,7 @@ De manera resumida, <a href="https://git-scm.com/" target="_blank">Git</a> es un
 
 Por otro lado, <a href="https://github.com/" target="_blank">Github</a> es un sitio web el cual nos permite guardar este código versionado tanto públicos como privados. Es acá donde distintos desarrolladores y desarrolladoras pueden observar nuestro código y contribur con el mismo si así lo quisieran. A pesar de que github es uno de los más importantes, no es el único, ya que existe <a href="https://about.gitlab.com/" target="_blank">Gitlab</a> y <a href="https://bitbucket.org/" target="_blank">Bitbucket</a>
 
-![stacks](/images/articulos/empezando-en-el-desarrollo-web/git-github.webp)
+![Flujo de trabajo con Git y repositorios en GitHub](/images/articulos/empezando-en-el-desarrollo-web/git-github.webp)
 
 <h2 id="que-sigue">¿Qué sigue?</h2>
 

--- a/src/pages/articles/introduccion-a-jamstack.mdx
+++ b/src/pages/articles/introduccion-a-jamstack.mdx
@@ -22,7 +22,7 @@ sections:
 
 Un stack en programación a una colección de tecnologías configuradas para trabajar entre si. Creo y sin miedo a equivocarme que el stack más conocido es el de **LAMP**-Stack (Por sus siglas de **L**inux, **A**pache, **M**ySQL y **P**hp). Otro stack muy conocido es el **MEAN**-Stack que viene de las tecnologías **M**ongoDB, **E**xpress, **A**ngular y **N**odejs. Posteriormente, con la aparición de **React**, se crea un nuevo stack ques es básicamente el mismo que el anterior, pero esta vez, cambiamos Angular por React. quedando como **MERN**-Stack. Con la aparición de Vuejs, este último stack sufrió un último cambio, cambiando a React por Vue, y por un momento el stack se llamó **MEVN** hasta que la comunidad re-ordenó las siglas quedando con el nombre de **VEN**o**M**.
 
-![stacks](/images/articulos/introduccion-a-jamstack/stacks.webp)
+![Comparativa de stacks de desarrollo web populares: LAMP, MEAN, MERN y VENOM](/images/articulos/introduccion-a-jamstack/stacks.webp)
 
 <h2 id="que-es-jam">¿Qué es JAM?</h2>
 
@@ -34,7 +34,7 @@ Las **APIs** se refieren a la o a las fuentes de datos que se utilizarán para l
 
 Cuando hablamos de **Markup compilado**, nos referimos a las vistas compiladas o generadas una sola vez, en vez de hacerlo con cada respuesta al momento de hacer la consulta al servidor (como tradicionalmente se hace).
 
-![stacks](/images/articulos/introduccion-a-jamstack/jam-stack.webp)
+![Diagrama de la arquitectura JAMstack: JavaScript, APIs y Markup compilado](/images/articulos/introduccion-a-jamstack/jam-stack.webp)
 
 <h2 id="buena-idea">Buena idea</h2>
 

--- a/src/pages/articles/no-querer-aprender-tambien-es-parte-del-proceso.mdx
+++ b/src/pages/articles/no-querer-aprender-tambien-es-parte-del-proceso.mdx
@@ -46,7 +46,7 @@ hacia "necesito saber mas y mas". El problema era que, cuanto más intentaba
 aprender, más me daba cuenta de que no estaba reteniendo nada. Era un "zombie
 del conocimiento", caminando por inercia, sintiéndome un poco perdido.
 
-![i-feel-disgusting](https://media.giphy.com/media/j6fjYi3rTxPBwxKDJO/giphy.gif)
+![Animación que expresa agotamiento y saturación mental](https://media.giphy.com/media/j6fjYi3rTxPBwxKDJO/giphy.gif)
 
 La decisión o insight
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import Subscribe from "../components/subscribe/index.astro";
 import { talks } from "../settings/talks";
 import type { Talk } from "../settings/talks";
 import { articlesSort } from "../utils/articles";
+import settings from "../settings";
 
 export const prerender = true;
 
@@ -20,9 +21,38 @@ posts.sort(articlesSort).splice(_MAX_ARTICLES);
 
 const featuredTalks = talks.filter((t: Talk) => t.show).slice(0, 3);
 
+const githubLink = settings.social_network.find((s) => s.name === "Github")?.link ?? "";
+const linkedinLink = settings.social_network.find((s) => s.name === "LinkedIn")?.link ?? "";
+const twitterLink = settings.contacts.find((c) => c.name === "Twitter")?.href ?? "";
+
+const schema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      name: settings.title,
+      url: settings.url,
+      potentialAction: {
+        "@type": "SearchAction",
+        target: `${settings.url}/articles?q={search_term_string}`,
+        "query-input": "required name=search_term_string",
+      },
+    },
+    {
+      "@type": "Person",
+      name: settings.author.name,
+      url: settings.url,
+      email: settings.email,
+      jobTitle: "Engineering Leader",
+      sameAs: [githubLink, linkedinLink, twitterLink].filter(Boolean),
+    },
+  ],
+};
+
 const seo = {
   title: "Eduardo Álvarez — Engineering Leadership & Platform Thinking",
   description: "Engineering Leadership & Platform Thinking in the AI Era.",
+  schema,
 };
 ---
 

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -4,7 +4,7 @@ import type { APIContext } from "astro";
 import config from "../settings/index.ts";
 import { articlesSort } from "../utils/articles.ts";
 
-const articlesFiles = import.meta.glob("./articulos/*.mdx", { eager: true });
+const articlesFiles = import.meta.glob("./articles/*.mdx", { eager: true });
 const articles = Object.values(articlesFiles).sort(articlesSort);
 
 export async function GET(context: APIContext) {
@@ -16,7 +16,7 @@ export async function GET(context: APIContext) {
     items: articles.map(({ frontmatter }) => {
       return {
         title: frontmatter.title,
-        link: `${config.url}/articulos/${frontmatter.slug}`,
+        link: `${config.url}/articles/${frontmatter.slug}`,
         pubDate: frontmatter.date,
         description: frontmatter.description,
         customData: `<author>${config.author.name}</author>`,

--- a/src/pages/speaking/index.astro
+++ b/src/pages/speaking/index.astro
@@ -34,7 +34,7 @@ const years = Object.keys(byYear)
         Charlas y talleres sobre liderazgo de ingeniería, arquitectura de plataformas y construcción con IA.
       </p>
       <p class="text-text-secondary text-sm">
-        ¿Quieres que hable en tu evento?{" "}
+       Me encantaría participar en tu evento, si quieres que hable en tu evento, escríbeme a{" "}
         <a
           href="mailto:soy@eduardoalvarez.dev"
           class="text-accent hover:underline"


### PR DESCRIPTION
## Summary

- Add `robots.txt` with standard directives (`User-agent: *`, `Disallow:`, `Sitemap:`)
- Fix `<html lang>` from `es` to `es-ES` to align with site settings
- Truncate meta description and `og:description` to 160 chars automatically
- Add `keywords?: string[]` to `Article` type for per-article keyword overrides
- Add dynamic `og:type` (`website` | `article`) with `article:published_time`, `article:author` and `article:tag` meta tags on article pages
- Add JSON-LD schema: `WebSite` + `Person` on homepage, `BlogPosting` on articles
- Add `<lastmod>` to sitemap using each article's frontmatter `date`
- Fix generic `alt="stacks"` on 5 images across 3 MDX articles
- Fix RSS feed glob and link URLs still pointing to old `/articulos/` path

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] `npm run lint` passes with no errors
- [x] `npm run test:unit` — 160/160 tests passing
- [x] `sitemap-0.xml` contains `<lastmod>` for all 6 articles (verified in local build)
- [x] `<html lang="es-ES">` confirmed in built `index.html`
- [x] `WebSite` + `Person` schemas confirmed in server bundle
- [x] `article:published_time`, `article:author`, `article:tag` confirmed in server bundle
- [ ] Verify `robots.txt`, schemas and Rich Results post-deploy (pending production)