### PR TITLE
feat(articles): macOS-style code blocks, scroll fix and v5.0.1 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19019,6 +19019,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19035,6 +19036,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19051,6 +19053,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19067,6 +19070,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19083,6 +19087,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19099,6 +19104,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19115,6 +19121,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19131,6 +19138,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19147,6 +19155,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19163,6 +19172,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19179,6 +19189,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19195,6 +19206,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19211,6 +19223,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19227,6 +19240,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19243,6 +19257,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19259,6 +19274,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19275,6 +19291,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19291,6 +19308,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19307,6 +19325,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19323,6 +19342,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19339,6 +19359,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19355,6 +19376,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19371,6 +19393,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19387,6 +19410,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19403,6 +19427,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19419,6 +19444,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19474,6 +19500,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eduardoalvarez.dev",
   "description": "My personal website",
-  "version": "4.0.4",
+  "version": "5.0.1",
   "type": "module",
   "keywords": [
     "react",

--- a/src/assets/styles/article.css
+++ b/src/assets/styles/article.css
@@ -10,6 +10,7 @@
   line-height: 1.2;
   margin-bottom: 1rem;
   padding-top: 3rem;
+  scroll-margin-top: 88px; /* nav-height (64px) + breathing room */
   color: #f5f5f5; /* text-primary */
 }
 
@@ -19,6 +20,7 @@
   line-height: 1.6;
   margin-bottom: 0.75rem;
   margin-top: 2rem;
+  scroll-margin-top: 88px; /* nav-height (64px) + breathing room */
   color: #f5f5f5; /* text-primary */
 }
 
@@ -116,10 +118,75 @@
   font-weight: 700;
 }
 
-#article-body pre {
-  background-color: #161616; /* surface-raised */
-  border-radius: 6px;
+#article-body .code-block-wrapper {
+  border-radius: 8px;
   margin-bottom: 1.5rem;
+  overflow: hidden;
+  border: 1px solid #1f1f1f; /* surface-border */
+}
+
+#article-body .code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #161616; /* surface-raised */
+  padding: 0.55rem 1rem;
+  border-bottom: 1px solid #1f1f1f; /* surface-border */
+}
+
+#article-body .code-traffic-lights {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+#article-body .code-traffic-lights span {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: block;
+}
+
+#article-body .code-traffic-lights span:nth-child(1) { background-color: #ff5f57; }
+#article-body .code-traffic-lights span:nth-child(2) { background-color: #febc2e; }
+#article-body .code-traffic-lights span:nth-child(3) { background-color: #28c840; }
+
+#article-body .code-language-label {
+  font-family: "Geist Mono", monospace;
+  font-size: 0.7rem;
+  color: #7c7c7c; /* text-muted */
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+#article-body .code-copy-btn {
+  font-family: "Geist Mono", monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  color: #7c7c7c; /* text-muted */
+  background: transparent;
+  border: 1px solid #1f1f1f; /* surface-border */
+  border-radius: 4px;
+  padding: 2px 8px;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+#article-body .code-copy-btn:hover {
+  color: #f5f5f5; /* text-primary */
+  border-color: #a3a3a3; /* text-secondary */
+}
+
+#article-body .code-copy-btn.copied {
+  color: #22c55e; /* success */
+  border-color: #22c55e;
+}
+
+#article-body pre {
+  background-color: #111111; /* surface */
+  border-radius: 0;
+  margin-bottom: 0;
   padding: 1.25rem;
   overflow-x: auto;
 }

--- a/src/layouts/article/index.astro
+++ b/src/layouts/article/index.astro
@@ -54,6 +54,57 @@ const seo: BaseHeadProps = {
 };
 ---
 
+<script>
+  function initCodeBlocks() {
+    const pres = document.querySelectorAll<HTMLElement>("#article-body pre[data-language]");
+    pres.forEach((pre) => {
+      if (pre.closest(".code-block-wrapper")) return;
+
+      const lang = pre.getAttribute("data-language") ?? "";
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "code-block-wrapper";
+
+      const header = document.createElement("div");
+      header.className = "code-block-header";
+
+      const lights = document.createElement("div");
+      lights.className = "code-traffic-lights";
+      lights.innerHTML = "<span></span><span></span><span></span>";
+
+      const label = document.createElement("span");
+      label.className = "code-language-label";
+      label.textContent = lang;
+
+      const copyBtn = document.createElement("button");
+      copyBtn.className = "code-copy-btn";
+      copyBtn.textContent = "Copiar";
+      copyBtn.addEventListener("click", () => {
+        const code = pre.querySelector("code");
+        const text = code ? code.innerText : pre.innerText;
+        navigator.clipboard.writeText(text).then(() => {
+          copyBtn.textContent = "Copiado";
+          copyBtn.classList.add("copied");
+          setTimeout(() => {
+            copyBtn.textContent = "Copiar";
+            copyBtn.classList.remove("copied");
+          }, 2000);
+        });
+      });
+
+      header.appendChild(lights);
+      header.appendChild(label);
+      header.appendChild(copyBtn);
+
+      pre.parentNode?.insertBefore(wrapper, pre);
+      wrapper.appendChild(header);
+      wrapper.appendChild(pre);
+    });
+  }
+
+  document.addEventListener("astro:page-load", initCodeBlocks);
+</script>
+
 <Layout seo={seo}>
   <article class="mx-auto max-w-full">
     <Head content={content} />


### PR DESCRIPTION
## Summary

- ✨ **macOS-style code block visualizer**: wraps Shiki `pre` blocks with a header bar featuring traffic lights (red/yellow/green), language label, and a \"Copiar\" button with 2s feedback — all using the existing design system tokens
- 🐛 **Scroll fix for TOC links**: adds `scroll-margin-top: 88px` to `h2`/`h3` so the sticky header (64px) no longer covers section headings when navigating from the aside TOC
- 🔖 **Version bump to 5.0.1**: reflects the rebrand (v5 major) plus all cumulative improvements in this cycle

## Test plan

- [ ] Open an article with code blocks and verify the macOS-style header appears (traffic lights, language label, copy button)
- [ ] Click \"Copiar\" and confirm clipboard content matches the code block; button shows \"Copiado\" briefly then resets
- [ ] Click a section link in the aside TOC and verify the heading is fully visible below the sticky header
- [ ] Confirm styles use design system tokens (no raw hex values outside `article.css`)
- [ ] Verify View Transitions: navigate between articles and confirm code blocks are re-initialized correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)