### PR TITLE
feat: update experience and add CaribeConf 2026 talk

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -116,3 +116,5 @@ extend-exclude = [
 "incentivos" = "incentivos"
 "internacional" = "internacional"
 "corporativo" = "corporativo"
+"cursos" = "cursos"
+"Cursos" = "Cursos"

--- a/.typos.toml
+++ b/.typos.toml
@@ -115,3 +115,4 @@ extend-exclude = [
 "cancelas" = "cancelas"
 "incentivos" = "incentivos"
 "internacional" = "internacional"
+"corporativo" = "corporativo"

--- a/src/layouts/base/components/header/constants/index.ts
+++ b/src/layouts/base/components/header/constants/index.ts
@@ -19,6 +19,12 @@ export const navItems: NavItem[] = [
     description: "Talks y workshops en conferencias",
   },
   {
+    name: "Cursos",
+    href: "https://cursos.eduardoalvarez.dev",
+    show: true,
+    description: "Cursos y formación técnica",
+  },
+  {
     name: "Sobre_mí",
     href: "/about",
     show: true,

--- a/src/settings/about.ts
+++ b/src/settings/about.ts
@@ -11,23 +11,24 @@ export const experience: Experience[] = [
     date: "2026 → hoy",
     role: "Technical Lead",
     company: "CMPC",
-    description: "Desarrollando estándares de desarrollo de software con IA.",
+    description:
+      "Liderando la evolución del ecosistema frontend corporativo (Design System y MicroFrontends) y el marco de Spec-Driven Development adoptado a nivel de toda la empresa, impulsando la adopción de IA en la forma de trabajar de los equipos de ingeniería.",
     current: true,
   },
   {
     date: "2025 → hoy",
     role: "CTO & CoFounder",
-    company: "Amipet",
+    company: "AmiPet",
     description:
       "Co-fundando una plataforma en el espacio pet-tech. Definiendo arquitectura, stack y roadmap técnico desde cero, con foco en validar product-market fit.",
     current: true,
   },
   {
-    date: "2024",
-    role: "Experienced consultant → Senior consultant",
+    date: "2024 → 2026",
+    role: "Senior Consultant / Technical Lead",
     company: "Amaris Consulting",
     description:
-      "Liderazgo de arquitectura frontend para plataformas enterprise. Diseño e implementación de arquitectura microfrontend con React, TypeScript y Single-SPA, reduciendo time-to-market en ~35%.",
+      "Liderazgo de arquitectura frontend para plataformas enterprise. Diseño e implementación de la arquitectura de MicroFrontends y el Design System corporativo (base técnica de más de 10 proyectos), con CLI y templates internos que redujeron el time-to-market en un 95%.",
     current: false,
   },
   {
@@ -39,7 +40,7 @@ export const experience: Experience[] = [
     current: false,
   },
   {
-    date: "2022",
+    date: "2021 → 2022",
     role: "Technical Lead",
     company: "DEUNA",
     description:

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -5,7 +5,7 @@ export default {
   keywords:
     "engineering leadership, platform architecture, platform thinking, AI era, engineering culture, software architecture, engineering management, staff engineer, typescript, react, node, astro",
   url: "https://eduardoalvarez.dev",
-  repo_url: "https://github.com/proskynete/website",
+  repo_url: "https://github.com/Proskynete/eduardoalvarez.dev",
   domain: "eduardoalvarez.dev",
   language: "es-ES",
   email: "soy@eduardoalvarez.dev",

--- a/src/settings/now.ts
+++ b/src/settings/now.ts
@@ -4,14 +4,14 @@ export interface NowItem {
   description?: string;
 }
 
-export const lastUpdated = "2026-03-04";
+export const lastUpdated = "2026-07-04";
 
 export const nowItems: NowItem[] = [
   {
     category: "Trabajando en",
     label: "Technical Lead en CMPC",
     description:
-      "Liderando el equipo de ingeniería para el cliente CMPC, coordinando decisiones técnicas, arquitectura y entrega de valor.",
+      "Liderando la evolución del ecosistema frontend corporativo y la adopción de IA en los equipos de ingeniería, con un marco de Spec-Driven Development adoptado a nivel de empresa.",
   },
   {
     category: "Trabajando en",

--- a/src/settings/talks.ts
+++ b/src/settings/talks.ts
@@ -43,6 +43,18 @@ export interface Talk {
 
 export const talks: Talk[] = [
   {
+    title: "Microfrontends sin dolor: cómo escalar React (y tu equipo) sin romperlo todo",
+    description:
+      "Cómo unificamos 12 aplicaciones separadas bajo una sola experiencia con microfrontends: React + Vite orquestados con single-spa, un design system compartido sobre shadcn/ui, librerías comunes y despliegue en GCP. Un marco de decisión honesto —basado en cicatrices propias— sobre cuándo SÍ y cuándo NO usar microfrontends.",
+    date: ["2026-08-14T14:00:00.000Z", "2026-08-15T22:00:00.000Z"],
+    show: true,
+    location: {
+      name: "CaribeConf — Barranquilla, Colombia",
+      url: "https://sessionize.com/caribeconf-2026/",
+    },
+    organizations: [],
+  },
+  {
     title: "Taller de Astro: Crea tu portafolio",
     description:
       "Aprenderemos de astro mientras creamos un sitio web donde podamos mostrar nuestras redes sociales, habilidades y proyectos. Este taller es ideal para quienes quieren aprender a crear un sitio web de forma rápida y sencilla, sin necesidad de tener experiencia previa en desarrollo web.",

--- a/tests/units/utils/articles.test.ts
+++ b/tests/units/utils/articles.test.ts
@@ -88,7 +88,7 @@ describe("articles utils", () => {
   describe("githubArticlePath", () => {
     it("debe generar la URL correcta para editar un artículo en GitHub", () => {
       const path = "mi-articulo";
-      const expected = "https://github.com/proskynete/website/edit/main/src/pages/articles/mi-articulo.mdx";
+      const expected = "https://github.com/Proskynete/eduardoalvarez.dev/edit/main/src/pages/articles/mi-articulo.mdx";
 
       const result = githubArticlePath(path);
 
@@ -101,16 +101,16 @@ describe("articles utils", () => {
       const results = paths.map(githubArticlePath);
 
       expect(results).toEqual([
-        "https://github.com/proskynete/website/edit/main/src/pages/articles/como-usar-react-hooks.mdx",
-        "https://github.com/proskynete/website/edit/main/src/pages/articles/typescript-para-principiantes.mdx",
-        "https://github.com/proskynete/website/edit/main/src/pages/articles/introduccion-a-astro.mdx",
+        "https://github.com/Proskynete/eduardoalvarez.dev/edit/main/src/pages/articles/como-usar-react-hooks.mdx",
+        "https://github.com/Proskynete/eduardoalvarez.dev/edit/main/src/pages/articles/typescript-para-principiantes.mdx",
+        "https://github.com/Proskynete/eduardoalvarez.dev/edit/main/src/pages/articles/introduccion-a-astro.mdx",
       ]);
     });
 
     it("debe manejar paths con caracteres especiales", () => {
       const path = "mi-articulo-con-números-123";
       const expected =
-        "https://github.com/proskynete/website/edit/main/src/pages/articles/mi-articulo-con-números-123.mdx";
+        "https://github.com/Proskynete/eduardoalvarez.dev/edit/main/src/pages/articles/mi-articulo-con-números-123.mdx";
 
       const result = githubArticlePath(path);
 
@@ -119,7 +119,7 @@ describe("articles utils", () => {
 
     it("debe manejar path vacío", () => {
       const path = "";
-      const expected = "https://github.com/proskynete/website/edit/main/src/pages/articles/.mdx";
+      const expected = "https://github.com/Proskynete/eduardoalvarez.dev/edit/main/src/pages/articles/.mdx";
 
       const result = githubArticlePath(path);
 


### PR DESCRIPTION
## Resumen

Alineación del contenido del sitio con la situación profesional actual (congruente con LinkedIn, CV web y CVs de Drive).

### /about y /now
- Descripción de **CMPC** actualizada: evolución del ecosistema frontend (Design System + MicroFrontends) y marco de **Spec-Driven Development** adoptado a nivel de empresa
- Se elimina la redacción de era-consultoría ("para el cliente CMPC") en /now
- **Amaris** cerrada como "2024 → 2026" con rol y logros consistentes con el CV (CLI + templates, time-to-market -95%)
- "Amipet" → "AmiPet" y fechas de DEUNA corregidas (2021 → 2022)

### /speaking
- Nueva charla: **"Microfrontends sin dolor: cómo escalar React (y tu equipo) sin romperlo todo"** — CaribeConf 2026, 14-15 de agosto, Barranquilla, Colombia (aceptada, 40 min)

### Fix
- `repo_url` apuntaba a `proskynete/website` (nombre antiguo del repo); ahora apunta a `Proskynete/eduardoalvarez.dev`. Tests unitarios actualizados.

### Verificación
- ✅ ESLint
- ✅ 160/160 tests unitarios
- ✅ `astro check && astro build` completo
- ✅ Página /speaking verificada visualmente con Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)